### PR TITLE
Introduce `with_attributes` view helper

### DIFF
--- a/lib/action_view/attributes_and_token_lists/attributes.rb
+++ b/lib/action_view/attributes_and_token_lists/attributes.rb
@@ -62,6 +62,7 @@ module ActionView
       end
       alias_method :+, :merge
       alias_method :|, :merge
+      alias_method :deep_merge, :merge
 
       def to_s
         html_ready_attributes = @attributes.transform_values do |value|

--- a/lib/action_view/attributes_and_token_lists/engine.rb
+++ b/lib/action_view/attributes_and_token_lists/engine.rb
@@ -10,6 +10,46 @@ module ActionView
             TokenList.wrap(build_tag_values(*tokens))
           end
           alias_method :class_names, :token_list
+
+          # Inspired by `Object#with_options`, when the `with_attributes` helper
+          # is called with a block,
+          # it yields a block argument that merges options into a base set of
+          # attributes. For example:
+          #
+          #   with_attributes class: "border rounded-sm p-4" do |styled|
+          #     styled.link_to "I'm styled!", "/"
+          #     #=> <a class="border rounded-sm p-4" href="/">I'm styled!</a>
+          #   end
+          #
+          # When the block is omitted, the object that would be the block
+          # parameter is returned:
+          #
+          #   styled = with_attributes class: "border rounded-sm p-4"
+          #   styled.link_to "I'm styled!", "/"
+          #   #=> <a class="border rounded-sm p-4" href="/">I'm styled!</a>
+          #
+          # To change the receiver from the view context, pass an object as the
+          # first argument:
+          #
+          #   button = with_attributes class: "border rounded-sm p-4"
+          #   button.link_to "I have a border", "/"
+          #   #=> <a class="border rounded-sm p-4" href="/">I have a border</a>
+          #
+          #   primary = with_attributes button, class: "text-red-500 border-red-500"
+          #   primary.link_to "I have a red border", "/"
+          #   #=> <a class="border rounded-sm p-4 text-red-500 border-red-500" href="/">I have a red border</a>
+          #
+          #   secondary = with_attributes button, class: "text-blue-500 border-blue-500"
+          #   secondary.link_to "I have a blue border", "/"
+          #   #=> <a class="border rounded-sm p-4 text-blue-500 border-blue-500" href="/">I have a blue border</a>
+          #
+          def with_attributes(context = self, **options, &block)
+            if block.nil?
+              ActiveSupport::OptionMerger.new context, tag.attributes(options)
+            else
+              context.with_options tag.attributes(options), &block
+            end
+          end
         end
 
         ActionView::Helpers::TagHelper::TagBuilder.module_eval do

--- a/test/helpers/action_view/helpers/tag_helper_test.rb
+++ b/test/helpers/action_view/helpers/tag_helper_test.rb
@@ -172,4 +172,27 @@ class ActionView::Helpers::TagHelperTest < ActionView::TestCase
     assert_kind_of ActionView::AttributesAndTokenLists::TokenList, tokens
     assert_equal %w[ one two ], tokens.to_a
   end
+
+  test "with_attributes can have options decorated onto it" do
+    with_attributes class: "one two" do |styled|
+      assert_equal %{<a class="one two" href="/">styled</a>}, styled.link_to("styled", "/")
+      assert_equal %{<a class="one two three" href="/">styled</a>}, styled.link_to("styled", "/", class: "three")
+    end
+  end
+
+  test "with_attributes accepts another Attributes instance to have options decorated onto" do
+    base = with_attributes class: "one two"
+    styled = with_attributes base, class: "three"
+
+    assert_equal %{<a class="one two" href="/">styled</a>}, base.link_to("styled", "/")
+    assert_equal %{<a class="one two three" href="/">styled</a>}, styled.link_to("styled", "/")
+    assert_equal %{<a class="one two three four" href="/">styled</a>}, styled.link_to("styled", "/", class: "four")
+  end
+
+  test "with_attributes accepts a context to have options decorated onto" do
+    styled = with_attributes tag, class: "one"
+
+    assert_equal(%{<a class="one" href="/">styled</a>}, styled.a(href: "/") { "styled" })
+    assert_equal(%{<a class="one two" href="/">styled</a>}, styled.a(class: "two", href: "/") { "styled" })
+  end
 end


### PR DESCRIPTION
Introduce the `with_attributes` view helper. Inspired by
`Object#with_options`, when the `with_attributes` helper is called with a block,
it yields a block argument that merges options into a base set of attributes.
For example:

```ruby
with_attributes class: "border rounded-sm p-4" do |styled|
  styled.link_to "I'm styled!", "/"
  # #=> <a class="border rounded-sm p-4" href="/">I'm styled!</a>
end
```

When the block is omitted, the object that would be the block parameter is
returned:

```ruby
 styled = with_attributes class: "border rounded-sm p-4"
 styled.link_to "I'm styled!", "/"
 # #=> <a class="border rounded-sm p-4" href="/">I'm styled!</a>
```

To change the receiver from the view context, pass an object as the first
argument:

```ruby
 button = with_attributes class: "border rounded-sm p-4"
 button.link_to "I have a border", "/"
 # #=> <a class="border rounded-sm p-4" href="/">I have a border</a>

 primary = with_attributes button, class: "text-red-500 border-red-500"
 primary.link_to "I have a red border", "/"
 # #=> <a class="border rounded-sm p-4 text-red-500 border-red-500" href="/">I have a red border</a>

 secondary = with_attributes button, class: "text-blue-500 border-blue-500"
 secondary.link_to "I have a blue border", "/"
 # #=> <a class="border rounded-sm p-4 text-blue-500 border-blue-500" href="/">I have a blue border</a>
```