### PR TITLE
Chain tag and with_attributes calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ the version links.
 
 ## main
 
-* Ensure that `Attributes` are compliant with Action View-provided `tag` helpers 
+* Enable chaining `#with_attributes` and `#tag` off of `Attributes` instances
+  and instances of `AttributeMerger` returned by other `#with_attributes` calls
+
+* Ensure that `Attributes` are compliant with Action View-provided `tag` helpers
 
 * Add `Attributes#with_attributes` and `Attributes#with_options` alias to enable
   decorating and chaining

--- a/README.md
+++ b/README.md
@@ -23,15 +23,25 @@ how to serialize themselves into HTML views through their `#to_s` methods.
 
 ```ruby
 def button
-  class_names "py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2"
+  tag.attributes class: "py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2"
 end
 
 def primary_button
-  button | "bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75"
+  button.with_attributes class: "bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75"
 end
 
-button_tag "Save", class: primary_button | "uppercase"
+primary_button.button_tag "Save", class: "uppercase"
 #=> "<button class="py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2 bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75 uppercase">Save</button>
+
+primary_button.link_to "Cancel", "/", class: "uppercase"
+#=> "<a href="/" class="py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2 bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75 uppercase">Cancel</a>
+
+primary_button.content_tag :a, "Cancel", href: "/", class: "uppercase"
+#=> "<a href="/" class="py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2 bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75 uppercase">Cancel</a>
+
+primary_button_builder = tag.with_attributes(primary_button)
+primary_button_builder.a "Cancel", href: "/", class: "uppercase"
+#=> "<a href="/" class="py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2 bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75 uppercase">Cancel</a>
 ```
 
 ### Summary
@@ -87,11 +97,11 @@ module ApplicationHelper
   end
 
   def button
-    class_names "py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2"
+    tag.attributes class: "py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2"
   end
 
-  def primary(context = self)
-    with_attributes context, class: button | "bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75"
+  def primary
+    button.with_attributes class: "bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75"
   end
 
   def pagination_controller
@@ -116,15 +126,17 @@ following diffs:
        Load more
      <% end %>
    </div>
+ <% end %>
 
+ <%= form_with url: sessions_path do |form| %>
 -  <%= form.button class: "colspan-2 py-2 px-4 bg-black text-white font-semibold rounded-lg shadow-md hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-yellow-300 focus:ring-opacity-75" do %>
-+  <%= primary(form).button class: "colspan-2" do %>
++  <%= form.button primary.merge(class: "colspan-2") do %>
      Sign in
    <% end %>
  <% end %>
 
--<section id="entries" class="max-w-prose max-w-sm w-full lg:w-1/3" data-controller="pagination sorted" data-sorted-attribute-name-value="data-code" data-action="turbo:before-cache@document->pagination#preserveScroll turbo:before-render@document->pagination#injectNextPageIntoBody">
-+<section id="entries" class="<%= feed_section %>" <%= pagination_controller | sorted_controller %>>
+-<section id="entries" class="max-w-prose max-w-sm w-full lg:w-1/3 font-medium" data-controller="pagination sorted" data-sorted-attribute-name-value="data-code" data-action="turbo:before-cache@document->pagination#preserveScroll turbo:before-render@document->pagination#injectNextPageIntoBody">
++<section id="entries" class="<%= feed_section | "font-medium" %>" <%= pagination_controller | sorted_controller %>>
    <%= render partial: "entries/page", object: @page %>
  </section>
 ```

--- a/lib/action_view/attributes_and_token_lists/attribute_merger.rb
+++ b/lib/action_view/attributes_and_token_lists/attribute_merger.rb
@@ -1,0 +1,36 @@
+module ActionView
+  module AttributesAndTokenLists
+    class AttributeMerger < ActiveSupport::OptionMerger
+      def initialize(view_context, context, options)
+        @view_context = view_context
+        super context, @view_context.tag.attributes(options.to_hash.with_indifferent_access)
+      end
+
+      def with_attributes(options, &block)
+        attribute_merger = AttributeMerger.new @view_context, @context, @options.merge(options)
+
+        if block.nil?
+          attribute_merger
+        else
+          block.arity.zero? ? attribute_merger.instance_eval(&block) : block.call(attribute_merger)
+        end
+      end
+
+      def tag(name = nil, options = nil, open = false, escape = true)
+        if [ name, options ].all?(&:nil?)
+          AttributeMerger.new(@view_context, @view_context.tag, @options)
+        else
+          @view_context.tag(name, @options.merge(options.to_h))
+        end
+      end
+
+      def to_hash
+        @options.to_hash
+      end
+
+      def to_h
+        @options.to_h
+      end
+    end
+  end
+end

--- a/lib/action_view/attributes_and_token_lists/attribute_merger.rb
+++ b/lib/action_view/attributes_and_token_lists/attribute_merger.rb
@@ -31,6 +31,11 @@ module ActionView
       def to_h
         @options.to_h
       end
+
+      def inspect
+        "#<%<class>s:0x%<addr>08x context=%<context>s>" %
+          { class: self.class, addr: object_id * 2, context: @context.inspect }
+      end
     end
   end
 end

--- a/lib/action_view/attributes_and_token_lists/attributes.rb
+++ b/lib/action_view/attributes_and_token_lists/attributes.rb
@@ -87,6 +87,11 @@ module ActionView
 
         @tag_builder.tag_options(html_ready_attributes).to_s.strip.html_safe
       end
+
+      def inspect
+        "#<%<class>s:0x%<addr>08x attributes=%<attributes>s>" %
+          { class: self.class, addr: object_id * 2, attributes: @attributes.inspect }
+      end
     end
   end
 end


### PR DESCRIPTION
Enables chaining `#with_attributes` and `#tag` off of `Attributes`
instances and instances of `AttributeMerger` returned by other
`#with_attributes` calls.

Declare #inspect to improve debugging experience
---

Declare `AttributeMerger#inspect` and `Attributes#inspect` to be more
succinct and clear about which attributes are ready to be forwarded.