### PR TITLE
Allow attributes.() shorthand merge syntax

### DIFF
--- a/lib/action_view/attributes_and_token_lists/attributes.rb
+++ b/lib/action_view/attributes_and_token_lists/attributes.rb
@@ -65,6 +65,7 @@ module ActionView
       end
       alias_method :+, :merge
       alias_method :|, :merge
+      alias_method :call, :merge
       alias_method :deep_merge, :merge
 
       def with_attributes(options, &block)


### PR DESCRIPTION
So callers can do an inline merge call like this

`aria.combobox.combobox_target.(aria: { expanded: params[:query].present? })`

instead of

`aria.combobox.combobox_target.merge aria: { expanded: params[:query].present? }`

It's not the best example because here the no-need for parentheses feels nice, but I still think there's validity to this.