### PR TITLE
Add syntactic sugar for top-level merges

### DIFF
--- a/lib/action_view/attributes_and_token_lists/attributes.rb
+++ b/lib/action_view/attributes_and_token_lists/attributes.rb
@@ -46,6 +46,14 @@ module ActionView
         @attributes = Attributes.deep_wrap_token_lists(attributes).with_indifferent_access
       end
 
+      def aria(**attributes)
+        merge(aria: attributes)
+      end
+
+      def data(**attributes)
+        merge(data: attributes)
+      end
+
       def merge(other)
         other = other.to_hash.with_indifferent_access
 

--- a/test/helpers/action_view/helpers/tag_helper_test.rb
+++ b/test/helpers/action_view/helpers/tag_helper_test.rb
@@ -74,6 +74,16 @@ class ActionView::Helpers::TagHelperTest < ActionView::TestCase
     assert_equal %(class="one two"), attributes.to_s
   end
 
+  test "tag.attributes.aria deeply merges" do
+    assert_equal %(aria-describedby="one two three"), tag.attributes(aria: { describedby: token_list("one") }).aria(describedby: "two").aria(describedby: "three").to_s
+    assert_equal %(aria-describedby="one two three"), tag.attributes(aria: { describedby: "one" }).aria(describedby: token_list("two")).aria(describedby: "three").to_s
+  end
+
+  test "tag.attributes.data deeply merges" do
+    assert_equal %(data-controller="one two three"), tag.attributes(data: { controller: token_list("one") }).data(controller: "two").data(controller: "three").to_s
+    assert_equal %(data-controller="one two three"), tag.attributes(data: { controller: "one" }).data(controller: token_list("two")).data(controller: "three").to_s
+  end
+
   test "tag.attributes deeply merges Hash attributes" do
     assert_equal %(data-controller="one two"), tag.attributes(data: { controller: token_list("one") }).merge(data: { controller: "two" }).to_s
     assert_equal %(data-controller="one two"), tag.attributes(data: { controller: "one" }).merge(data: { controller: token_list("two") }).to_s


### PR DESCRIPTION
So calls can go from

`aria.combobox.combobox_target.(aria: { expanded: params[:query].present? })`

and become

`aria.combobox.combobox_target.aria(expanded: params[:query].present?)`

This should work for `data` too:

`aria.combobox.combobox_target.data(action: "turbo-load@document->combobox#reset")`

Also should be combinable ala `combobox_target.aria(expanded: true).aria(description: "hey").data(action: "yup")`

@seanpdoyle what do you think about this? I just used GitHub's online editor but I can flesh this out more later.