### PR TITLE
Omit `escape:` keyword from `#tag_string`

### DIFF
--- a/lib/action_view/attributes_and_token_lists/engine.rb
+++ b/lib/action_view/attributes_and_token_lists/engine.rb
@@ -84,12 +84,12 @@ module ActionView
           alias_method :overridden_tag_string, :tag_string
           private :overridden_tag_string
 
-          def tag_string(name, content = nil, escape: true, **options, &block)
+          def tag_string(name, content = nil, **options, &block)
             case content
             when Attributes, AttributeMerger
-              overridden_tag_string(name, **content.to_hash.merge(options), escape: escape, &block)
+              overridden_tag_string(name, **content.to_hash.merge(options), &block)
             else
-              overridden_tag_string(name, content, escape: escape, **options, &block)
+              overridden_tag_string(name, content, **options, &block)
             end
           end
 


### PR DESCRIPTION
As a follow-up to [3095fc7][], omit the `escape:` keyword entirely
(which was renamed from `escape_attributes:` in
[rails/rails@648516c][]).

[3095fc7]: https://github.com/seanpdoyle/action_view-attributes_and_token_lists/pull/6/commits/3095fc746db2c2168c1114a6404b877d3089d284
[rails/rails@648516c]: https://github.com/rails/rails/commit/649516ce0feb699ae06a8c5e81df75d460cc9a85