### PR TITLE
Simplify

### DIFF
--- a/lib/action_view/attributes_and_token_lists/attribute_merger.rb
+++ b/lib/action_view/attributes_and_token_lists/attribute_merger.rb
@@ -3,7 +3,7 @@ module ActionView
     class AttributeMerger < ActiveSupport::OptionMerger
       def initialize(view_context, context, options)
         @view_context = view_context
-        super context, @view_context.tag.attributes(options.to_hash.with_indifferent_access)
+        super context, @view_context.tag.attributes(options)
       end
 
       def with_attributes(options, &block)
@@ -17,7 +17,7 @@ module ActionView
       end
 
       def tag(name = nil, options = nil, open = false, escape = true)
-        if [name, options].all?(&:nil?)
+        if name.nil? && options.nil?
           AttributeMerger.new(@view_context, @view_context.tag, @options)
         else
           @view_context.tag(name, @options.merge(options.to_h))

--- a/lib/action_view/attributes_and_token_lists/token_list.rb
+++ b/lib/action_view/attributes_and_token_lists/token_list.rb
@@ -22,7 +22,7 @@ module ActionView
       end
 
       def union(other)
-        TokenList.wrap(@tokens | Array(other).to_set)
+        TokenList.wrap(@tokens.union(Set[*other]))
       end
       alias_method :merge, :union
       alias_method :+, :union


### PR DESCRIPTION
* reduce the amount of `Attribute` to `Hash` coercion
* use explicit `&&` instead of `Enumerable#all?`
* Call `Set#union` instead of difficult-to-Google-for `Set#|` overloaded
  operator syntax