### PR TITLE
Remove private Action View class references

### DIFF
--- a/app/helpers/action_view/attributes_and_token_lists/application_helper.rb
+++ b/app/helpers/action_view/attributes_and_token_lists/application_helper.rb
@@ -7,7 +7,7 @@ module ActionView
   module AttributesAndTokenLists
     module ApplicationHelper
       def token_list(*tokens)
-        TokenList.wrap(build_tag_values(*tokens))
+        TokenList.wrap(super(*tokens))
       end
       alias_method :class_names, :token_list
 

--- a/lib/action_view/attributes_and_token_lists/attributes.rb
+++ b/lib/action_view/attributes_and_token_lists/attributes.rb
@@ -30,10 +30,10 @@ module ActionView
         relevant
       ].flat_map { |key| [key, key.to_s] }.freeze
 
-      def self.deep_wrap_token_lists(attributes)
+      def self.deep_wrap_token_lists(view_context, attributes)
         attributes.deep_merge(attributes) do |attribute, value|
           if attribute.in?(TOKEN_LIST_ATTRIBUTES | NESTED_TOKEN_LISTS_ATTRIBUTES)
-            ActionView::AttributesAndTokenLists::TokenList.wrap(ActionView::Helpers::TagHelper.build_tag_values(value))
+            view_context.token_list(value)
           else
             value
           end
@@ -43,7 +43,7 @@ module ActionView
       def initialize(tag_builder, view_context, **attributes)
         @tag_builder = tag_builder
         @view_context = view_context
-        @attributes = Attributes.deep_wrap_token_lists(attributes).with_indifferent_access
+        @attributes = Attributes.deep_wrap_token_lists(view_context, attributes).with_indifferent_access
       end
 
       def aria(**attributes)


### PR DESCRIPTION
In their place, decorate methods that rely on public interfaces. For
example, remove calls to
[ActionView::Helpers::TagHelper.build_tag_values][], and instead rely on
the value returned by calls to `token_list`.

[ActionView::Helpers::TagHelper.build_tag_values]: https://github.com/rails/rails/blob/6f20be9f972340ecb2dabb21c95598238b9c260f/actionview/lib/action_view/helpers/tag_helper.rb#L401-L420