### PR TITLE
Refactor: Unified, Consistent

### DIFF
--- a/app/helpers/attributes_and_token_lists/application_helper.rb
+++ b/app/helpers/attributes_and_token_lists/application_helper.rb
@@ -20,10 +20,6 @@ module AttributesAndTokenLists
       end
     end
 
-    def content_tag(...)
-      tag.public_send(...)
-    end
-
     # Inspired by `Object#with_options`, when the `with_attributes` helper
     # is called with a block,
     # it yields a block argument that merges options into a base set of
@@ -57,10 +53,8 @@ module AttributesAndTokenLists
     #   secondary.link_to "I have a blue border", "/"
     #   #=> <a class="border rounded-sm p-4 text-blue-500 border-blue-500" href="/">I have a blue border</a>
     #
-    def with_attributes(*options, **overrides, &block)
-      attributes = options.reduce({}, :merge)
-
-      AttributeMerger.new(self, self, attributes).with_attributes(**overrides, &block)
+    def with_attributes(*hashes, **overrides, &block)
+      AttributeMerger.new(self, self, [*hashes, overrides]).with_attributes(&block)
     end
   end
 end

--- a/lib/attributes_and_token_lists/attribute_merger.rb
+++ b/lib/attributes_and_token_lists/attribute_merger.rb
@@ -2,12 +2,11 @@ module AttributesAndTokenLists
   class AttributeMerger < ActiveSupport::OptionMerger
     def initialize(view_context, context, options)
       @view_context = view_context
-      super context, @view_context.tag.attributes(options)
+      super context, @view_context.tag.attributes(*options)
     end
 
-    def with_attributes(*options, **overrides, &block)
-      attributes = [*options, overrides].reduce(@options, :merge)
-      attribute_merger = AttributeMerger.new @view_context, @context, attributes
+    def with_attributes(*hashes, **overrides, &block)
+      attribute_merger = AttributeMerger.new(@view_context, @context, [@options, *hashes, overrides])
 
       if block.nil?
         attribute_merger
@@ -18,7 +17,7 @@ module AttributesAndTokenLists
 
     def tag(name = nil, options = nil, open = false, escape = true)
       if name.nil? && options.nil?
-        AttributeMerger.new(@view_context, @view_context.tag, @options)
+        TagBuilder.new(@view_context, @view_context.tag, [@options])
       else
         @view_context.tag(name, @options.merge(options.to_h))
       end

--- a/lib/attributes_and_token_lists/attributes.rb
+++ b/lib/attributes_and_token_lists/attributes.rb
@@ -37,9 +37,9 @@ module AttributesAndTokenLists
       end
     end
 
-    def initialize(tag_builder, view_context, **attributes)
-      @tag_builder = tag_builder
+    def initialize(view_context, tag_builder, **attributes)
       @view_context = view_context
+      @tag_builder = tag_builder
       @attributes = Attributes.deep_wrap_token_lists(view_context, attributes).with_indifferent_access
     end
 
@@ -58,7 +58,7 @@ module AttributesAndTokenLists
         value, override = @attributes[key], other[key]
 
         if value.is_a?(Hash) && override.is_a?(Hash)
-          Attributes.new(@tag_builder, @view_context).merge(value).merge(override)
+          Attributes.new(@view_context, @tag_builder).merge(value).merge(override)
         elsif value.respond_to?(:merge)
           value.merge(override)
         else
@@ -66,7 +66,7 @@ module AttributesAndTokenLists
         end
       end
 
-      Attributes.new(@tag_builder, @view_context, **attributes)
+      Attributes.new(@view_context, @tag_builder, **attributes)
     end
     alias_method :call, :merge
     alias_method :deep_merge, :merge
@@ -79,7 +79,7 @@ module AttributesAndTokenLists
     alias_method :with_options, :with_attributes
 
     def tag
-      AttributeMerger.new(@view_context, @view_context.tag, self)
+      TagBuilder.new(@view_context, @view_context.tag, [self])
     end
 
     def to_s

--- a/lib/attributes_and_token_lists/tag_builder.rb
+++ b/lib/attributes_and_token_lists/tag_builder.rb
@@ -3,7 +3,7 @@ module AttributesAndTokenLists
     def initialize(view_context, tag, attributes = [])
       @view_context = view_context
       @tag = tag
-      @attributes = attributes
+      @attributes = attributes.reduce(Attributes.new(view_context, tag), :merge)
     end
 
     # Transforms a Hash into HTML Attributes, ready to be interpolated into
@@ -12,11 +12,11 @@ module AttributesAndTokenLists
     #   <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %> >
     #   # => <input type="text" aria-label="Search">
     def attributes(*options, **overrides)
-      [*options, overrides].reduce(Attributes.new(@tag, @view_context), :merge)
+      [*options, overrides].reduce(@attributes, :merge)
     end
 
-    def with_attributes(*attributes, **options)
-      TagBuilder.new(@view_context, @tag, [*@attributes, *attributes, options])
+    def with_attributes(*hashes, **overrides, &block)
+      AttributeMerger.new(@view_context, self, [*hashes, overrides]).with_attributes(&block)
     end
 
     def method_missing(name, content = nil, *arguments, escape: true, **options, &block)
@@ -28,7 +28,7 @@ module AttributesAndTokenLists
         content = @view_context.capture(self, &block) if block
       end
 
-      @tag.public_send(name, content, escape: escape, **attributes(*@attributes, *arguments, **options), &block)
+      @tag.public_send(name, content, escape: escape, **attributes(*arguments, **options), &block)
     end
 
     def respond_to_missing?(name, include_private = false)


### PR DESCRIPTION
First, ensure variable ordered and keyword arguments are named consistently to communicate they're an `Array` of `Hash` instances and keyword argument overrides.

Next, invoke `AttributeMerger#with_attributes` consistently. Whenever possible, avoid it in favor of `TagBuilder` instances.

Then, make sure that the various constructors all accept `view_context` as their first argument.

Finally, remove the unnecessary `content_tag` method declared in `app/helpers/attributes_and_token_lists/application_helper.rb`.