### PR TITLE
Drop support for `app/views/initializers` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ the version links.
 
 ## main
 
+* Drop support for loading `AttributesAndTokenLists.builder` calls from
+  `app/views/initializers`.
+
+  *Sean Doyle*
+
 * Replace `AttributesAndTokenLists::Attributes` with `ActionView::Attributes` to
   make it more `Hash`-like.
 

--- a/lib/attributes_and_token_lists/engine.rb
+++ b/lib/attributes_and_token_lists/engine.rb
@@ -44,10 +44,6 @@ module AttributesAndTokenLists
     config.to_prepare do
       AttributesAndTokenLists.config = ::Rails.configuration.attributes_and_token_lists
 
-      begin
-        ApplicationController.renderer.render(template: "initializers/attributes_and_token_lists")
-      rescue ActionView::MissingTemplate
-      end
       ActiveSupport.run_load_hooks :attributes_and_token_lists, AttributesAndTokenLists
 
       AttributesAndTokenLists.define_builder_helper_methods(ActionView::Base)

--- a/test/dummy/app/views/initializers/attributes_and_token_lists.html.erb
+++ b/test/dummy/app/views/initializers/attributes_and_token_lists.html.erb
@@ -1,9 +1,0 @@
-<%
-  AttributesAndTokenLists.builder :view_initializer do
-    base :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
-      variant :primary, class: "bg-green-500"
-      variant :secondary, class: "bg-blue-500"
-      variant :tertiary, class: "bg-black"
-    end
-  end
-%>

--- a/test/integration/tag_builder_test.rb
+++ b/test/integration/tag_builder_test.rb
@@ -1,27 +1,6 @@
 require "test_helper"
 
 class TagBuilderTest < ActionDispatch::IntegrationTest
-  test "reads configuration from app/views/initializers" do
-    post examples_path, params: {template: <<~ERB}
-      <%= view_initializer.tag.button "Unstyled" %>
-      <%= view_initializer.button.tag "Base" %>
-      <%= view_initializer.button.primary "Primary" %>
-      <%= view_initializer.button.secondary "Secondary" %>
-      <%= view_initializer.button.tertiary "Tertiary" %>
-      <%= view_initializer.button.primary.a "Primary", href: "#" %>
-      <%= view_initializer.button.primary.link_to "Primary", "#" %>
-      <%= view_initializer.button.with(:primary, :secondary, :tertiary).tag "All" %>
-    ERB
-
-    assert_button "Unstyled", class: %w[]
-    assert_button "Base", class: %w[text-white p-4 focus:outline-none focus:ring]
-    assert_button "Primary", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500]
-    assert_button "Secondary", class: %w[text-white p-4 focus:outline-none focus:ring bg-blue-500]
-    assert_button "Tertiary", class: %w[text-white p-4 focus:outline-none focus:ring bg-black]
-    assert_link "Primary", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500], href: "#", count: 2
-    assert_button "All", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500 bg-blue-500 bg-black]
-  end
-
   test "reads configuration from config/initializers" do
     post examples_path, params: {template: <<~ERB}
       <%= initializer.tag.button "Unstyled" %>


### PR DESCRIPTION
Drop support for loading `AttributesAndTokenLists.builder` calls from `app/views/initializers` in favor of
`config/initializers/attributes_and_token_lists.rb`.